### PR TITLE
fix: replace Math.abs with tenary statements

### DIFF
--- a/imagetracer_v1.2.6.js
+++ b/imagetracer_v1.2.6.js
@@ -315,7 +315,11 @@ function ImageTracer(){
 					for( k=0; k<palette.length; k++ ){
 						
 						// In my experience, https://en.wikipedia.org/wiki/Rectilinear_distance works better than https://en.wikipedia.org/wiki/Euclidean_distance
-						cd = Math.abs(palette[k].r-imgd.data[idx]) + Math.abs(palette[k].g-imgd.data[idx+1]) + Math.abs(palette[k].b-imgd.data[idx+2]) + Math.abs(palette[k].a-imgd.data[idx+3]);
+						cd = 
+							( palette[k].r > imgd.data[idx  ] ? palette[k].r - imgd.data[idx  ] : imgd.data[idx  ] - palette[k].r ) +
+							( palette[k].g > imgd.data[idx+1] ? palette[k].g - imgd.data[idx+1] : imgd.data[idx+1] - palette[k].g ) +
+							( palette[k].b > imgd.data[idx+2] ? palette[k].b - imgd.data[idx+2] : imgd.data[idx+2] - palette[k].b ) +
+							( palette[k].a > imgd.data[idx+3] ? palette[k].a - imgd.data[idx+3] : imgd.data[idx+3] - palette[k].a );
 						
 						// Remember this color if this is the closest yet
 						if(cd<cdl){ cdl = cd; ci = k; }


### PR DESCRIPTION
This will help improve the performance in Chrome

Hi @jankovicsandras , we have experienced "Intermittent slowdown in `colorquantization` function" in our application(same as #38 )
I have narrowed it down to a for loop inside of `colorquantization` and it seems that the Math.abs inside of that forloop is causing the performance issue. So I have replaced the Math.abs with a tenary statement and it resolved the problem. (Not sure why Math.abs is rnning slow on Chrome but not on Firefox)

![image](https://user-images.githubusercontent.com/23226111/93279436-1ba49e00-f77c-11ea-9a3a-7bc92e42106f.png)
